### PR TITLE
Configure a blacklist of attributes that shouldn't be cloned

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,21 @@ After clicking on **clone** you will see this **dialog**:
 
 Put in a new **product code** and click on **save**. After that check if all the data is correct for the new product.
 
+### Configuration
+
+You don't need to configure this bundle by default.
+The default behaviour is to clone all product or product model attributes except the unique attributes.
+In addition, you can specify a blacklist of attributes that shouldn't be cloned:
+
+``` yaml
+flagbit_product_cloner:
+    attribute_blacklist:
+        - your_attribute_code1
+        - your_attribute_code2
+        - your_attribute_code3
+        ...
+```
+
 ## Akeneo Compatibility ##
 
 This extension supports the latest Akeneo PIM CE/EE stable versions:

--- a/src/Controller/AbstractController.php
+++ b/src/Controller/AbstractController.php
@@ -14,6 +14,8 @@ abstract class AbstractController extends Controller
 
     abstract protected function getAttributeRepository() : AttributeRepositoryInterface;
 
+    abstract protected function getAttributeCodeBlacklist() : array;
+
     protected function normalizeProduct(EntityWithFamilyVariantInterface $product)
     {
         $normalizedProduct = $this->getNormalizer()->normalize($product, 'external_api');
@@ -25,9 +27,14 @@ abstract class AbstractController extends Controller
                 unset($normalizedProduct['values'][$value->getAttributeCode()]);
             }
             $product = $parent;
-        };
+        }
 
-        foreach ($this->getAttributeRepository()->findUniqueAttributeCodes() as $attributeCode) {
+        $ignoredAttributeCodes = array_merge(
+            $this->getAttributeRepository()->findUniqueAttributeCodes(),
+            $this->getAttributeCodeBlacklist()
+        );
+
+        foreach ($ignoredAttributeCodes as $attributeCode) {
             unset($normalizedProduct['values'][$attributeCode]);
         }
         unset($normalizedProduct['identifier']);

--- a/src/Controller/AbstractController.php
+++ b/src/Controller/AbstractController.php
@@ -14,7 +14,10 @@ abstract class AbstractController extends Controller
 
     abstract protected function getAttributeRepository() : AttributeRepositoryInterface;
 
-    abstract protected function getAttributeCodeBlacklist() : array;
+    protected function getAttributeCodeBlacklist() : array
+    {
+        return [];
+    }
 
     protected function normalizeProduct(EntityWithFamilyVariantInterface $product)
     {

--- a/src/Controller/ProductController.php
+++ b/src/Controller/ProductController.php
@@ -25,54 +25,71 @@ class ProductController extends AbstractController
      * @var ProductRepositoryInterface
      */
     private $productRepository;
+
     /**
      * @var ObjectUpdaterInterface
      */
     private $productUpdater;
+
     /**
      * @var SaverInterface
      */
     private $productSaver;
+
     /**
      * @var NormalizerInterface
      */
     private $normalizer;
+
     /**
      * @var ValidatorInterface
      */
     private $validator;
+
     /**
      * @var UserContext
      */
     private $userContext;
+
     /**
      * @var ProductBuilderInterface
      */
     private $productBuilder;
+
     /**
      * @var AttributeConverterInterface
      */
     private $localizedConverter;
+
     /**
      * @var FilterInterface
      */
     private $emptyValuesFilter;
+
     /**
      * @var ConverterInterface
      */
     private $productValueConverter;
+
     /**
      * @var NormalizerInterface
      */
     private $constraintViolationNormalizer;
+
     /**
      * @var ProductBuilderInterface
      */
     private $variantProductBuilder;
+
     /**
      * @var AttributeRepositoryInterface
      */
     private $attributeRepository;
+
+    /**
+     * @var string[]
+     */
+    private $attributeCodeBlacklist;
 
     public function __construct(
         ProductRepositoryInterface $productRepository,
@@ -87,7 +104,8 @@ class ProductController extends AbstractController
         FilterInterface $emptyValuesFilter,
         ConverterInterface $productValueConverter,
         NormalizerInterface $constraintViolationNormalizer,
-        ProductBuilderInterface $variantProductBuilder
+        ProductBuilderInterface $variantProductBuilder,
+        array $attributeCodeBlacklist
     ) {
 
         $this->productRepository = $productRepository;
@@ -103,6 +121,7 @@ class ProductController extends AbstractController
         $this->constraintViolationNormalizer = $constraintViolationNormalizer;
         $this->variantProductBuilder = $variantProductBuilder;
         $this->attributeRepository = $attributeRepository;
+        $this->attributeCodeBlacklist = $attributeCodeBlacklist;
     }
 
     /**
@@ -214,6 +233,14 @@ class ProductController extends AbstractController
         }
 
         $this->productUpdater->update($product, $data);
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getAttributeCodeBlacklist() : array
+    {
+        return $this->attributeCodeBlacklist;
     }
 
     protected function getNormalizer() : NormalizerInterface

--- a/src/Controller/ProductController.php
+++ b/src/Controller/ProductController.php
@@ -105,7 +105,7 @@ class ProductController extends AbstractController
         ConverterInterface $productValueConverter,
         NormalizerInterface $constraintViolationNormalizer,
         ProductBuilderInterface $variantProductBuilder,
-        array $attributeCodeBlacklist
+        array $attributeCodeBlacklist = []
     ) {
 
         $this->productRepository = $productRepository;

--- a/src/Controller/ProductModelController.php
+++ b/src/Controller/ProductModelController.php
@@ -50,23 +50,17 @@ class ProductModelController extends AbstractController
      * @var NormalizerInterface
      */
     private $violationNormalizer;
+
     /**
      * @var AttributeRepositoryInterface
      */
     private $attributeRepository;
 
     /**
-     * DefaultController constructor.
-     *
-     * @param ProductModelRepositoryInterface $productModelRepository
-     * @param NormalizerInterface             $normalizer
-     * @param SimpleFactoryInterface          $productModelFactory
-     * @param ObjectUpdaterInterface          $productModelUpdater
-     * @param SaverInterface                  $productModelSaver
-     * @param ValidatorInterface              $validator
-     * @param NormalizerInterface             $violiationNormalizer
-     * @param AttributeRepositoryInterface    $attributeRepository
+     * @var string[]
      */
+    private $attributeCodeBlacklist;
+
     public function __construct(
         ProductModelRepositoryInterface $productModelRepository,
         AttributeRepositoryInterface $attributeRepository,
@@ -75,7 +69,8 @@ class ProductModelController extends AbstractController
         ObjectUpdaterInterface $productModelUpdater,
         SaverInterface $productModelSaver,
         ValidatorInterface $validator,
-        NormalizerInterface $violiationNormalizer
+        NormalizerInterface $violationNormalizer,
+        array $attributeCodeBlacklist
     ) {
         $this->productModelRepository = $productModelRepository;
         $this->normalizer = $normalizer;
@@ -83,8 +78,9 @@ class ProductModelController extends AbstractController
         $this->productModelUpdater = $productModelUpdater;
         $this->productModelSaver = $productModelSaver;
         $this->validator = $validator;
-        $this->violationNormalizer = $violiationNormalizer;
+        $this->violationNormalizer = $violationNormalizer;
         $this->attributeRepository = $attributeRepository;
+        $this->attributeCodeBlacklist = $attributeCodeBlacklist;
     }
 
     /**
@@ -151,6 +147,14 @@ class ProductModelController extends AbstractController
         } catch (\Exception $e) {
             return new JsonResponse(['values' => [['message' => $e->getMessage()]]], Response::HTTP_BAD_REQUEST);
         }
+    }
+
+    /**
+     * @return string[]
+     */
+    protected function getAttributeCodeBlacklist() : array
+    {
+        return $this->attributeCodeBlacklist;
     }
 
     protected function getNormalizer() : NormalizerInterface

--- a/src/Controller/ProductModelController.php
+++ b/src/Controller/ProductModelController.php
@@ -70,7 +70,7 @@ class ProductModelController extends AbstractController
         SaverInterface $productModelSaver,
         ValidatorInterface $validator,
         NormalizerInterface $violationNormalizer,
-        array $attributeCodeBlacklist
+        array $attributeCodeBlacklist = []
     ) {
         $this->productModelRepository = $productModelRepository;
         $this->normalizer = $normalizer;

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -8,7 +8,8 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 /**
  * This is the class that validates and merges configuration from your app/config files
  *
- * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html#cookbook-bundles-extension-config-class}
+ * To learn more see
+ * {@link http://symfony.com/doc/current/cookbook/bundles/extension.html#cookbook-bundles-extension-config-class}
  */
 class Configuration implements ConfigurationInterface
 {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Flagbit\Bundle\ProductClonerBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+
+/**
+ * This is the class that validates and merges configuration from your app/config files
+ *
+ * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/extension.html#cookbook-bundles-extension-config-class}
+ */
+class Configuration implements ConfigurationInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function getConfigTreeBuilder()
+    {
+        $treeBuilder = new TreeBuilder();
+        $root = $treeBuilder->root('flagbit_product_cloner');
+
+        $root->children()
+            ->arrayNode('attribute_blacklist')
+                ->info('A list of attribute codes that need to be left out for the clone')
+                ->defaultValue([])
+                ->scalarPrototype()
+                    ->info('Valid attribute codes')
+                ->end()
+            ->end()
+        ->end();
+
+        return $treeBuilder;
+    }
+}

--- a/src/DependencyInjection/FlagbitProductClonerExtension.php
+++ b/src/DependencyInjection/FlagbitProductClonerExtension.php
@@ -19,6 +19,11 @@ class FlagbitProductClonerExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
+        $configuration = new Configuration();
+        $processedConfig = $this->processConfiguration($configuration, $configs);
+
+        $container->setParameter('flagbit_product_cloner.attribute_blacklist', $processedConfig['attribute_blacklist']);
+
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
     }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -10,6 +10,7 @@ services:
             - '@pim_catalog.saver.product_model'
             - '@pim_catalog.validator.product'
             - '@pim_enrich.normalizer.violation'
+            - '%flagbit_product_cloner.attribute_blacklist%'
     flagbit_product_cloner.controller.product:
         class: Flagbit\Bundle\ProductClonerBundle\Controller\ProductController
         arguments:
@@ -26,3 +27,4 @@ services:
             - '@pim_enrich.converter.enrich_to_standard.product_value'
             - '@pim_enrich.normalizer.product_violation'
             - '@pim_catalog.builder.product'
+            - '%flagbit_product_cloner.attribute_blacklist%'


### PR DESCRIPTION
Like unique values don't appear in the cloned product, this feature allows to configure a blacklist of attributes that should be ignored on cloning too.

This is a customer feature request and is currently an undocumented feature. Because of the current product cloner design, this feature will introduce a BC break in `AbstractController`.