### PR TITLE
Compatibility to Akeneo 3.2

### DIFF
--- a/src/Controller/ProductModelController.php
+++ b/src/Controller/ProductModelController.php
@@ -125,6 +125,7 @@ class ProductModelController extends AbstractController
 
             // clone product using Akeneo normalizer and updater for reusing code
             $normalizedProduct = $this->normalizeProduct($productModel);
+            unset($normalizedProduct['family']);
             $this->productModelUpdater->update($cloneProductModel, $normalizedProduct);
             $this->productModelUpdater->update($cloneProductModel, $content);
             $cloneProductModel->setCode($content['code']);


### PR DESCRIPTION
This PR targets the Akeneo 3.2 version to make the cloning process compatible with it. The only issue I found to make this bundle compatible with 3.2 was the already mentioned one in #21.